### PR TITLE
support for go 1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: required
 language: go
 go:
   - 1.13.x
+  - 1.14.x
   - master
 
 matrix:
@@ -12,15 +13,25 @@ matrix:
         - make clean
         - NOASM=0 make test
         - NOASM=1 make test
-        - NOASM=0 make cover
-        - NOASM=1 make cover
-    - name: "Go on ARM64"
+    - name: "Go 1.13 on ARM64"
       services: docker
       os: linux
       script:
         - docker run --rm --privileged multiarch/qemu-user-static:register --reset
-        - docker run --rm -v `pwd`:`pwd` -w `pwd` "flowher/debian-buster-aarch64-go" /bin/bash -c "NOASM=0 make test"
-        - docker run --rm -v `pwd`:`pwd` -w `pwd` "flowher/debian-buster-aarch64-go" /bin/bash -c "NOASM=1 make test"
+        - docker run --rm -v `pwd`:`pwd` -w `pwd` "flowher/debian-buster-aarch64-go-1.13" /bin/bash -c "NOASM=0 make test"
+        - docker run --rm -v `pwd`:`pwd` -w `pwd` "flowher/debian-buster-aarch64-go-1.13" /bin/bash -c "NOASM=1 make test"
+    - name: "Go 1.14 on ARM64"
+      services: docker
+      os: linux
+      script:
+        - docker run --rm --privileged multiarch/qemu-user-static:register --reset
+        - docker run --rm -v `pwd`:`pwd` -w `pwd` "flowher/debian-buster-aarch64-go-1.14" /bin/bash -c "NOASM=0 make test"
+        - docker run --rm -v `pwd`:`pwd` -w `pwd` "flowher/debian-buster-aarch64-go-1.14" /bin/bash -c "NOASM=1 make test"
+    - name: "Coverage"
+      os: linux
+      script:
+        - NOASM=0 make cover
+        - NOASM=1 make cover
 
 
 after_script:

--- a/etc/dockers/debian-buster-aarch64/Dockerfile_1_13
+++ b/etc/dockers/debian-buster-aarch64/Dockerfile_1_13
@@ -4,8 +4,8 @@ RUN apt-get upgrade -y
 RUN apt-get update -qq
 USER root
 RUN apt-get install -y make wget ca-certificates
-RUN wget https://dl.google.com/go/go1.12.5.linux-arm64.tar.gz
-RUN tar -xzf go1.12.5.linux-arm64.tar.gz
+RUN wget https://dl.google.com/go/go1.13.linux-arm64.tar.gz
+RUN tar -xzf go1.13.linux-arm64.tar.gz
 RUN mv go /usr/local/
 RUN ln -s /usr/local/go/bin/go /usr/bin/
-RUN rm -rf /var/lib/apt/lists/* go1.12.5.linux-arm64.tar.gz
+RUN rm -rf /var/lib/apt/lists/* go1.13.linux-arm64.tar.gz

--- a/etc/dockers/debian-buster-aarch64/Dockerfile_1_14
+++ b/etc/dockers/debian-buster-aarch64/Dockerfile_1_14
@@ -1,0 +1,11 @@
+FROM multiarch/debian-debootstrap:arm64-buster
+
+RUN apt-get upgrade -y
+RUN apt-get update -qq
+USER root
+RUN apt-get install -y make wget ca-certificates
+RUN wget https://dl.google.com/go/go1.14.linux-arm64.tar.gz
+RUN tar -xzf go1.14.linux-arm64.tar.gz
+RUN mv go /usr/local/
+RUN ln -s /usr/local/go/bin/go /usr/bin/
+RUN rm -rf /var/lib/apt/lists/* go1.14.linux-arm64.tar.gz


### PR DESCRIPTION
NOBS now supports Go 1.14 for

* x86-64
* ARMv8

Both optimized and unoptimized implementation works correctly